### PR TITLE
Fix setup

### DIFF
--- a/.zshrc.d/hdd.zsh
+++ b/.zshrc.d/hdd.zsh
@@ -275,7 +275,6 @@ function hdd() {
                 echo ""
                 eval "$2 ${@:4}"
             fi
-            unset -f $2
         else
             echo "$(font fg_red)hdd $1 is not available!$(font reset)"
         fi

--- a/.zshrc.d/zsh.zsh
+++ b/.zshrc.d/zsh.zsh
@@ -2,7 +2,7 @@
 # ZSHRC Configuration
 # ---------------------------------------
 
-ZSHRC_VERSION="1.5.0"
+ZSHRC_VERSION="1.5.1"
 
 function __zshrc_help() {
     echo "   $(font bold fg_cyan)                                   zshrc                                    $(font reset)

--- a/setup.zsh
+++ b/setup.zsh
@@ -19,7 +19,7 @@ ZSHRC_FILES_ESSENTIAL=(
     "zsh"
     "hdd"
     "blkidf"
-    ".blkid_impl"
+    ".blkidf_impl"
     "alias"
     "mobaxterm"
 )

--- a/setup.zsh
+++ b/setup.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-echo "ZSHRC Setup                                                     1.5.0"
+echo "ZSHRC Setup                                                     1.5.1"
 echo "──────────────────────────────────────────────────────────────────────────"
 echo "   Loading components…"
 


### PR DESCRIPTION
A missing character in `setup.zsh` broke `blkidf` entirely.